### PR TITLE
Reduce invalid state chance

### DIFF
--- a/nft-minter/src/common_storage.rs
+++ b/nft-minter/src/common_storage.rs
@@ -10,7 +10,7 @@ pub type Uri<M> = ManagedBuffer<M>;
 pub type MediaType<M> = ManagedBuffer<M>;
 pub type GenericAttributes<M> = ManagedBuffer<M>;
 
-#[derive(TypeAbi, TopEncode, TopDecode)]
+#[derive(TypeAbi, TopEncode, TopDecode, NestedEncode, NestedDecode)]
 pub struct BrandInfo<M: ManagedTypeApi> {
     pub collection_id: CollectionId<M>,
     pub token_display_name: ManagedBuffer<M>,
@@ -18,7 +18,7 @@ pub struct BrandInfo<M: ManagedTypeApi> {
     pub royalties: BigUint<M>,
 }
 
-#[derive(TypeAbi, TopEncode, TopDecode)]
+#[derive(TypeAbi, TopEncode, TopDecode, NestedEncode, NestedDecode)]
 pub struct MintPrice<M: ManagedTypeApi> {
     pub start_timestamp: u64,
     pub token_id: TokenIdentifier<M>,


### PR DESCRIPTION
Do most of the logic in success callback instead of error callback. This reduces the chance of the SC running into "out of gas" errors on the "error" branch of the callback (since it will only have the gas the little gas the VM reserved for it).

Stored manually into storage instead of using the built-in callback args from the framework so they're only loaded on success branch manually instead of being automatically loaded in both branches.