### PR TITLE
Royalties handler impl

### DIFF
--- a/nft-minter/src/nft_marketplace_interactor.rs
+++ b/nft-minter/src/nft_marketplace_interactor.rs
@@ -26,6 +26,8 @@ pub trait NftMarketplaceInteractorModule:
         marketplace_address: ManagedAddress,
         #[var_args] tokens: MultiValueEncoded<TokenIdentifier>,
     ) {
+        self.require_caller_is_admin();
+
         let mut args = MultiValueEncoded::new();
         for token in tokens {
             args.push((token, 0).into());

--- a/royalties-handler/Cargo.toml
+++ b/royalties-handler/Cargo.toml
@@ -8,6 +8,9 @@ publish = false
 [lib]
 path = "src/lib.rs"
 
+[dependencies.nft-minter]
+path = "../nft-minter"
+
 [dependencies.elrond-wasm]
 version = "0.30.0"
 

--- a/royalties-handler/src/common_storage.rs
+++ b/royalties-handler/src/common_storage.rs
@@ -1,0 +1,11 @@
+elrond_wasm::imports!();
+
+#[elrond_wasm::module]
+pub trait CommonStorageModule {
+    #[view(getLastClaimEpoch)]
+    #[storage_mapper("lastClaimEpoch")]
+    fn last_claim_epoch(&self) -> SingleValueMapper<u64>;
+
+    #[storage_mapper("accumulatedPayments")]
+    fn accumulated_payments(&self) -> MapMapper<TokenIdentifier, BigUint>;
+}

--- a/royalties-handler/src/common_storage.rs
+++ b/royalties-handler/src/common_storage.rs
@@ -6,6 +6,7 @@ pub trait CommonStorageModule {
     #[storage_mapper("lastClaimEpoch")]
     fn last_claim_epoch(&self) -> SingleValueMapper<u64>;
 
-    #[storage_mapper("accumulatedPayments")]
-    fn accumulated_payments(&self) -> MapMapper<TokenIdentifier, BigUint>;
+    #[view(getShareholders)]
+    #[storage_mapper("shareholders")]
+    fn shareholders(&self) -> UnorderedSetMapper<ManagedAddress>;
 }

--- a/royalties-handler/src/lib.rs
+++ b/royalties-handler/src/lib.rs
@@ -4,13 +4,17 @@ elrond_wasm::imports!();
 
 pub mod common_storage;
 pub mod nft_minter_interactor;
+pub mod reward_entries;
 pub mod shareholders;
+pub mod token_balance;
 
 #[elrond_wasm::contract]
 pub trait RoyaltiesHandler:
     common_storage::CommonStorageModule
     + nft_minter_interactor::NftMinterInteractorModule
     + shareholders::ShareholdersModule
+    + reward_entries::RewardEntriesModule
+    + token_balance::TokenBalanceModule
 {
     #[init]
     fn init(
@@ -26,8 +30,7 @@ pub trait RoyaltiesHandler:
         self.nft_minter_sc_address().set(&nft_minter_sc_address);
         self.add_shareholders(shareholders);
 
-        // init reward entry list
-        self.first_entry_number().set_if_empty(&1);
-        self.last_entry_number().set_if_empty(&1);
+        // init first entry ID
+        self.first_entry_id().set(&1);
     }
 }

--- a/royalties-handler/src/lib.rs
+++ b/royalties-handler/src/lib.rs
@@ -2,8 +2,32 @@
 
 elrond_wasm::imports!();
 
+pub mod common_storage;
+pub mod nft_minter_interactor;
+pub mod shareholders;
+
 #[elrond_wasm::contract]
-pub trait RoyaltiesHandler {
+pub trait RoyaltiesHandler:
+    common_storage::CommonStorageModule
+    + nft_minter_interactor::NftMinterInteractorModule
+    + shareholders::ShareholdersModule
+{
     #[init]
-    fn init(&self) {}
+    fn init(
+        &self,
+        nft_minter_sc_address: ManagedAddress,
+        #[var_args] shareholders: MultiValueEncoded<ManagedAddress>,
+    ) {
+        require!(
+            self.blockchain().is_smart_contract(&nft_minter_sc_address),
+            "Invalid NFT Minter SC address"
+        );
+
+        self.nft_minter_sc_address().set(&nft_minter_sc_address);
+        self.add_shareholders(shareholders);
+
+        // init reward entry list
+        self.first_entry_number().set_if_empty(&1);
+        self.last_entry_number().set_if_empty(&1);
+    }
 }

--- a/royalties-handler/src/lib.rs
+++ b/royalties-handler/src/lib.rs
@@ -29,8 +29,5 @@ pub trait RoyaltiesHandler:
 
         self.nft_minter_sc_address().set(&nft_minter_sc_address);
         self.add_shareholders(shareholders);
-
-        // init first entry ID
-        self.first_entry_id().set(&1);
     }
 }

--- a/royalties-handler/src/nft_minter_interactor.rs
+++ b/royalties-handler/src/nft_minter_interactor.rs
@@ -3,7 +3,9 @@ elrond_wasm::imports!();
 use nft_minter::{common_storage::EgldValuePaymentsVecPair, royalties::ProxyTrait as _};
 
 #[elrond_wasm::module]
-pub trait NftMinterInteractorModule: crate::common_storage::CommonStorageModule {
+pub trait NftMinterInteractorModule:
+    crate::common_storage::CommonStorageModule + crate::token_balance::TokenBalanceModule
+{
     #[only_owner]
     #[endpoint(claimNftMinterPaymentsAndRoyalties)]
     fn claim_nft_minter_payments_and_royalties(&self) {
@@ -16,14 +18,13 @@ pub trait NftMinterInteractorModule: crate::common_storage::CommonStorageModule 
 
         self.last_claim_epoch().set(&current_epoch);
 
-        let mut mapper = self.accumulated_payments();
         let sc_address = self.nft_minter_sc_address().get();
 
         let royalties_result = self.call_claim_royalties(sc_address.clone());
-        self.update_balance_from_results(&mut mapper, royalties_result);
+        self.update_balance_from_results(royalties_result);
 
         let mint_payments_result = self.call_claim_mint_payments(sc_address);
-        self.update_balance_from_results(&mut mapper, mint_payments_result);
+        self.update_balance_from_results(mint_payments_result);
     }
 
     fn call_claim_royalties(
@@ -42,38 +43,6 @@ pub trait NftMinterInteractorModule: crate::common_storage::CommonStorageModule 
         self.nft_minter_proxy(sc_address)
             .claim_mint_payments()
             .execute_on_dest_context()
-    }
-
-    fn update_balance_from_results(
-        &self,
-        mapper: &mut MapMapper<TokenIdentifier, BigUint>,
-        result: EgldValuePaymentsVecPair<Self::Api>,
-    ) {
-        let (egld_value, other_payments) = result.into_tuple();
-
-        if egld_value > 0 {
-            self.add_single_payment(mapper, TokenIdentifier::egld(), egld_value);
-        }
-        for p in &other_payments {
-            self.add_single_payment(mapper, p.token_identifier, p.amount);
-        }
-    }
-
-    fn add_single_payment(
-        &self,
-        mapper: &mut MapMapper<TokenIdentifier, BigUint>,
-        token: TokenIdentifier,
-        amount: BigUint,
-    ) {
-        match mapper.get(&token) {
-            Some(mut prev_amount) => {
-                prev_amount += amount;
-                let _ = mapper.insert(token, prev_amount);
-            }
-            None => {
-                let _ = mapper.insert(token, amount);
-            }
-        }
     }
 
     #[proxy]

--- a/royalties-handler/src/nft_minter_interactor.rs
+++ b/royalties-handler/src/nft_minter_interactor.rs
@@ -1,0 +1,85 @@
+elrond_wasm::imports!();
+
+use nft_minter::{common_storage::EgldValuePaymentsVecPair, royalties::ProxyTrait as _};
+
+#[elrond_wasm::module]
+pub trait NftMinterInteractorModule: crate::common_storage::CommonStorageModule {
+    #[only_owner]
+    #[endpoint(claimNftMinterPaymentsAndRoyalties)]
+    fn claim_nft_minter_payments_and_royalties(&self) {
+        let current_epoch = self.blockchain().get_block_epoch();
+        let last_claim_epoch = self.last_claim_epoch().get();
+        require!(
+            current_epoch > last_claim_epoch,
+            "Already claimed this epoch"
+        );
+
+        self.last_claim_epoch().set(&current_epoch);
+
+        let mut mapper = self.accumulated_payments();
+        let sc_address = self.nft_minter_sc_address().get();
+
+        let royalties_result = self.call_claim_royalties(sc_address.clone());
+        self.update_balance_from_results(&mut mapper, royalties_result);
+
+        let mint_payments_result = self.call_claim_mint_payments(sc_address);
+        self.update_balance_from_results(&mut mapper, mint_payments_result);
+    }
+
+    fn call_claim_royalties(
+        &self,
+        sc_address: ManagedAddress,
+    ) -> EgldValuePaymentsVecPair<Self::Api> {
+        self.nft_minter_proxy(sc_address)
+            .claim_royalties()
+            .execute_on_dest_context()
+    }
+
+    fn call_claim_mint_payments(
+        &self,
+        sc_address: ManagedAddress,
+    ) -> EgldValuePaymentsVecPair<Self::Api> {
+        self.nft_minter_proxy(sc_address)
+            .claim_mint_payments()
+            .execute_on_dest_context()
+    }
+
+    fn update_balance_from_results(
+        &self,
+        mapper: &mut MapMapper<TokenIdentifier, BigUint>,
+        result: EgldValuePaymentsVecPair<Self::Api>,
+    ) {
+        let (egld_value, other_payments) = result.into_tuple();
+
+        if egld_value > 0 {
+            self.add_single_payment(mapper, TokenIdentifier::egld(), egld_value);
+        }
+        for p in &other_payments {
+            self.add_single_payment(mapper, p.token_identifier, p.amount);
+        }
+    }
+
+    fn add_single_payment(
+        &self,
+        mapper: &mut MapMapper<TokenIdentifier, BigUint>,
+        token: TokenIdentifier,
+        amount: BigUint,
+    ) {
+        match mapper.get(&token) {
+            Some(mut prev_amount) => {
+                prev_amount += amount;
+                let _ = mapper.insert(token, prev_amount);
+            }
+            None => {
+                let _ = mapper.insert(token, amount);
+            }
+        }
+    }
+
+    #[proxy]
+    fn nft_minter_proxy(&self, sc_address: ManagedAddress) -> nft_minter::Proxy<Self::Api>;
+
+    #[view(getNftMinterScAddress)]
+    #[storage_mapper("nftMinterScAddress")]
+    fn nft_minter_sc_address(&self) -> SingleValueMapper<ManagedAddress>;
+}

--- a/royalties-handler/src/reward_entries.rs
+++ b/royalties-handler/src/reward_entries.rs
@@ -2,6 +2,8 @@ elrond_wasm::imports!();
 
 use nft_minter::common_storage::PaymentsVec;
 
+pub const FIRST_ENTRY_ID: usize = 1;
+
 #[elrond_wasm::module]
 pub trait RewardEntriesModule:
     crate::common_storage::CommonStorageModule + crate::token_balance::TokenBalanceModule
@@ -71,10 +73,6 @@ pub trait RewardEntriesModule:
     #[view(getLastRewardEntryEpoch)]
     #[storage_mapper("lastRewardEntryEpoch")]
     fn last_reward_entry_epoch(&self) -> SingleValueMapper<u64>;
-
-    #[view(getFirstEntryId)]
-    #[storage_mapper("firstEntryId")]
-    fn first_entry_id(&self) -> SingleValueMapper<usize>;
 
     #[view(getLastEntryId)]
     #[storage_mapper("lastEntryId")]

--- a/royalties-handler/src/reward_entries.rs
+++ b/royalties-handler/src/reward_entries.rs
@@ -1,0 +1,92 @@
+elrond_wasm::imports!();
+
+use nft_minter::common_storage::PaymentsVec;
+
+#[elrond_wasm::module]
+pub trait RewardEntriesModule:
+    crate::common_storage::CommonStorageModule + crate::token_balance::TokenBalanceModule
+{
+    #[only_owner]
+    #[endpoint(createNewRewardEntry)]
+    fn create_new_reward_entry(&self) {
+        let current_epoch = self.blockchain().get_block_epoch();
+        let last_claim_epoch = self.last_claim_epoch().get();
+        require!(
+            current_epoch == last_claim_epoch,
+            "Must claim rewards for this epoch first"
+        );
+
+        self.last_reward_entry_epoch()
+            .update(|last_reward_entry_epoch| {
+                require!(
+                    *last_reward_entry_epoch != current_epoch,
+                    "Already created reward entry for this epoch"
+                );
+
+                *last_reward_entry_epoch = current_epoch;
+            });
+
+        let nr_shareholders = self.shareholders().len() as u32;
+        require!(nr_shareholders > 0, "No shareholders");
+
+        let mut rewards_entry = PaymentsVec::new();
+        for token_id in self.known_tokens().iter() {
+            let balance_mapper = self.balance_for_token(&token_id);
+            let balance = balance_mapper.get();
+
+            // nothing to split
+            if balance < nr_shareholders {
+                continue;
+            }
+
+            let amount_per_holder = &balance / nr_shareholders;
+            let dust = balance - (&amount_per_holder * nr_shareholders);
+            balance_mapper.set(&dust);
+
+            rewards_entry.push(EsdtTokenPayment::new(token_id, 0, amount_per_holder));
+        }
+
+        let entry_id = self.store_new_reward_entry(&rewards_entry);
+        self.copy_shareholders_to_claim_whitelist(entry_id);
+    }
+
+    fn store_new_reward_entry(&self, entry: &PaymentsVec<Self::Api>) -> usize {
+        let new_entry_id = self.last_entry_id().update(|id| {
+            *id += 1;
+            *id
+        });
+        self.claimable_tokens_for_reward_entry(new_entry_id)
+            .set(entry);
+
+        new_entry_id
+    }
+
+    fn copy_shareholders_to_claim_whitelist(&self, entry_id: usize) {
+        let mut new_mapper = self.claim_whitelist_for_entry(entry_id);
+        for sh in self.shareholders().iter() {
+            new_mapper.insert(sh);
+        }
+    }
+
+    #[view(getLastRewardEntryEpoch)]
+    #[storage_mapper("lastRewardEntryEpoch")]
+    fn last_reward_entry_epoch(&self) -> SingleValueMapper<u64>;
+
+    #[view(getFirstEntryId)]
+    #[storage_mapper("firstEntryId")]
+    fn first_entry_id(&self) -> SingleValueMapper<usize>;
+
+    #[view(getLastEntryId)]
+    #[storage_mapper("lastEntryId")]
+    fn last_entry_id(&self) -> SingleValueMapper<usize>;
+
+    #[storage_mapper("claimableTokensForRewardEntry")]
+    fn claimable_tokens_for_reward_entry(
+        &self,
+        entry_id: usize,
+    ) -> SingleValueMapper<PaymentsVec<Self::Api>>;
+
+    #[view(getClaimWhitelistForEntry)]
+    #[storage_mapper("claimWhitelistForEntry")]
+    fn claim_whitelist_for_entry(&self, entry_id: usize) -> UnorderedSetMapper<ManagedAddress>;
+}

--- a/royalties-handler/src/shareholders.rs
+++ b/royalties-handler/src/shareholders.rs
@@ -1,0 +1,97 @@
+use nft_minter::common_storage::PaymentsVec;
+
+elrond_wasm::imports!();
+elrond_wasm::derive_imports!();
+
+#[derive(TypeAbi, TopEncode, TopDecode)]
+pub struct RewardsForEntryNumber<M: ManagedTypeApi> {
+    pub rewards: PaymentsVec<M>,
+}
+
+#[elrond_wasm::module]
+pub trait ShareholdersModule: crate::common_storage::CommonStorageModule {
+    #[only_owner]
+    #[endpoint(addShareholders)]
+    fn add_shareholders(&self, #[var_args] shareholders: MultiValueEncoded<ManagedAddress>) {
+        let mut mapper = self.shareholders();
+        for sh in shareholders {
+            let _ = mapper.insert(sh);
+        }
+    }
+
+    #[only_owner]
+    #[endpoint(removeShareholders)]
+    fn remove_shareholders(&self, #[var_args] shareholders: MultiValueEncoded<ManagedAddress>) {
+        let mut mapper = self.shareholders();
+        for sh in shareholders {
+            let _ = mapper.swap_remove(&sh);
+        }
+    }
+
+    #[only_owner]
+    #[endpoint(createNewRewardEntry)]
+    fn create_new_reward_entry(&self) {
+        let current_epoch = self.blockchain().get_block_epoch();
+        let last_claim_epoch = self.last_claim_epoch().get();
+        require!(
+            current_epoch == last_claim_epoch,
+            "Must claim rewards for this epoch first"
+        );
+
+        self.last_reward_entry_epoch()
+            .update(|last_reward_entry_epoch| {
+                require!(
+                    *last_reward_entry_epoch != current_epoch,
+                    "Already created reward entry for this epoch"
+                );
+
+                *last_reward_entry_epoch = current_epoch;
+            });
+
+        let nr_shareholders = self.shareholders().len() as u32;
+        require!(nr_shareholders > 0, "No shareholders");
+
+        let mut mapper = self.accumulated_payments();
+        for it in mapper.iter() {
+            let (token_id, amount): (TokenIdentifier, BigUint) = it;
+
+            // nothing to split
+            if amount < nr_shareholders {
+                continue;
+            }
+
+            let amount_per_holder = &amount / nr_shareholders;
+            let dust = amount - (&amount_per_holder * nr_shareholders);
+            let _ = mapper.insert(token_id.clone(), dust);
+        }
+    }
+
+    fn store_new_reward_entry(&self, entry: RewardsForEntryNumber<Self::Api>) {}
+
+    #[view(getLastRewardEntryEpoch)]
+    #[storage_mapper("lastRewardEntryEpoch")]
+    fn last_reward_entry_epoch(&self) -> SingleValueMapper<u64>;
+
+    #[view(getFirstEntryNumber)]
+    #[storage_mapper("firstEntryNumber")]
+    fn first_entry_number(&self) -> SingleValueMapper<usize>;
+
+    #[view(getLastEntryNumber)]
+    #[storage_mapper("lastEntryNumber")]
+    fn last_entry_number(&self) -> SingleValueMapper<usize>;
+
+    #[view(claimableTokensForRewardEntry)]
+    #[storage_mapper("claimableTokensForRewardEntry")]
+    fn claimable_tokens_for_reward_entry(
+        &self,
+        nr_entry: usize,
+    ) -> SingleValueMapper<RewardsForEntryNumber<Self::Api>>;
+
+    #[view(getClaimWhitelistForEntry)]
+    #[storage_mapper("claimWhitelistForEntry")]
+    fn claim_whitelist_for_entry(&self, nr_entry: usize) -> UnorderedSetMapper<ManagedAddress>;
+
+    #[view(getShareholders)]
+    #[storage_mapper("shareholders")]
+    fn shareholders(&self) -> UnorderedSetMapper<ManagedAddress>;
+}

--- a/royalties-handler/src/shareholders.rs
+++ b/royalties-handler/src/shareholders.rs
@@ -1,15 +1,12 @@
-use nft_minter::common_storage::PaymentsVec;
-
 elrond_wasm::imports!();
 elrond_wasm::derive_imports!();
 
-#[derive(TypeAbi, TopEncode, TopDecode)]
-pub struct RewardsForEntryNumber<M: ManagedTypeApi> {
-    pub rewards: PaymentsVec<M>,
-}
-
 #[elrond_wasm::module]
-pub trait ShareholdersModule: crate::common_storage::CommonStorageModule {
+pub trait ShareholdersModule:
+    crate::common_storage::CommonStorageModule
+    + crate::reward_entries::RewardEntriesModule
+    + crate::token_balance::TokenBalanceModule
+{
     #[only_owner]
     #[endpoint(addShareholders)]
     fn add_shareholders(&self, #[var_args] shareholders: MultiValueEncoded<ManagedAddress>) {
@@ -28,70 +25,17 @@ pub trait ShareholdersModule: crate::common_storage::CommonStorageModule {
         }
     }
 
-    #[only_owner]
-    #[endpoint(createNewRewardEntry)]
-    fn create_new_reward_entry(&self) {
-        let current_epoch = self.blockchain().get_block_epoch();
-        let last_claim_epoch = self.last_claim_epoch().get();
-        require!(
-            current_epoch == last_claim_epoch,
-            "Must claim rewards for this epoch first"
-        );
-
-        self.last_reward_entry_epoch()
-            .update(|last_reward_entry_epoch| {
-                require!(
-                    *last_reward_entry_epoch != current_epoch,
-                    "Already created reward entry for this epoch"
-                );
-
-                *last_reward_entry_epoch = current_epoch;
-            });
-
-        let nr_shareholders = self.shareholders().len() as u32;
-        require!(nr_shareholders > 0, "No shareholders");
-
-        let mut mapper = self.accumulated_payments();
-        for it in mapper.iter() {
-            let (token_id, amount): (TokenIdentifier, BigUint) = it;
-
-            // nothing to split
-            if amount < nr_shareholders {
-                continue;
-            }
-
-            let amount_per_holder = &amount / nr_shareholders;
-            let dust = amount - (&amount_per_holder * nr_shareholders);
-            let _ = mapper.insert(token_id.clone(), dust);
-        }
-    }
-
-    fn store_new_reward_entry(&self, entry: RewardsForEntryNumber<Self::Api>) {}
-
-    #[view(getLastRewardEntryEpoch)]
-    #[storage_mapper("lastRewardEntryEpoch")]
-    fn last_reward_entry_epoch(&self) -> SingleValueMapper<u64>;
-
-    #[view(getFirstEntryNumber)]
-    #[storage_mapper("firstEntryNumber")]
-    fn first_entry_number(&self) -> SingleValueMapper<usize>;
-
-    #[view(getLastEntryNumber)]
-    #[storage_mapper("lastEntryNumber")]
-    fn last_entry_number(&self) -> SingleValueMapper<usize>;
-
     #[view(claimableTokensForRewardEntry)]
-    #[storage_mapper("claimableTokensForRewardEntry")]
-    fn claimable_tokens_for_reward_entry(
+    fn get_claimable_tokens_for_reward_entry(
         &self,
-        nr_entry: usize,
-    ) -> SingleValueMapper<RewardsForEntryNumber<Self::Api>>;
+        entry_id: usize,
+    ) -> MultiValueEncoded<MultiValue2<TokenIdentifier, BigUint>> {
+        let mut result = MultiValueEncoded::new();
+        let payments = self.claimable_tokens_for_reward_entry(entry_id).get();
+        for p in &payments {
+            result.push((p.token_identifier, p.amount).into());
+        }
 
-    #[view(getClaimWhitelistForEntry)]
-    #[storage_mapper("claimWhitelistForEntry")]
-    fn claim_whitelist_for_entry(&self, nr_entry: usize) -> UnorderedSetMapper<ManagedAddress>;
-
-    #[view(getShareholders)]
-    #[storage_mapper("shareholders")]
-    fn shareholders(&self) -> UnorderedSetMapper<ManagedAddress>;
+        result
+    }
 }

--- a/royalties-handler/src/shareholders.rs
+++ b/royalties-handler/src/shareholders.rs
@@ -1,6 +1,8 @@
 elrond_wasm::imports!();
 elrond_wasm::derive_imports!();
 
+use crate::reward_entries::FIRST_ENTRY_ID;
+
 #[elrond_wasm::module]
 pub trait ShareholdersModule:
     crate::common_storage::CommonStorageModule
@@ -23,6 +25,54 @@ pub trait ShareholdersModule:
         for sh in shareholders {
             let _ = mapper.swap_remove(&sh);
         }
+    }
+
+    #[endpoint(claimRewards)]
+    fn claim_rewards(&self, #[var_args] entry_ids: MultiValueEncoded<usize>) {
+        let caller = self.blockchain().get_caller();
+        for entry_id in entry_ids {
+            let mut whitelist_mapper = self.claim_whitelist_for_entry(entry_id);
+            if !whitelist_mapper.contains(&caller) {
+                continue;
+            }
+
+            let rewards_entry_mapper = self.claimable_tokens_for_reward_entry(entry_id);
+            let payments = rewards_entry_mapper.get();
+
+            let _ = whitelist_mapper.swap_remove(&caller);
+            if whitelist_mapper.is_empty() {
+                rewards_entry_mapper.clear();
+            }
+
+            self.send().direct_multi(&caller, &payments, &[]);
+        }
+    }
+
+    #[view(getClaimableEntryIdsForAddress)]
+    fn get_claimable_entry_ids_for_address(
+        &self,
+        address: ManagedAddress,
+        nr_entries_to_look_back: usize,
+    ) -> MultiValueEncoded<usize> {
+        let mut result = MultiValueEncoded::new();
+        let last_id = self.last_entry_id().get();
+        if last_id == 0 {
+            return result;
+        }
+
+        let first_id = if nr_entries_to_look_back >= last_id {
+            FIRST_ENTRY_ID
+        } else {
+            last_id - nr_entries_to_look_back
+        };
+
+        for id in first_id..=last_id {
+            if self.claim_whitelist_for_entry(id).contains(&address) {
+                result.push(id);
+            }
+        }
+
+        result
     }
 
     #[view(claimableTokensForRewardEntry)]

--- a/royalties-handler/src/token_balance.rs
+++ b/royalties-handler/src/token_balance.rs
@@ -1,0 +1,44 @@
+use nft_minter::common_storage::EgldValuePaymentsVecPair;
+
+elrond_wasm::imports!();
+
+#[elrond_wasm::module]
+pub trait TokenBalanceModule {
+    fn add_balance(&self, token: TokenIdentifier, amount: &BigUint) {
+        self.balance_for_token(&token).update(|b| {
+            *b += amount;
+        });
+        let _ = self.known_tokens().insert(token);
+    }
+
+    fn update_balance_from_results(&self, result: EgldValuePaymentsVecPair<Self::Api>) {
+        let (egld_value, other_payments) = result.into_tuple();
+
+        if egld_value > 0 {
+            self.add_balance(TokenIdentifier::egld(), &egld_value);
+        }
+        for p in &other_payments {
+            self.add_balance(p.token_identifier, &p.amount);
+        }
+    }
+
+    #[view(getTokenBalances)]
+    fn get_token_balances(&self) -> MultiValueEncoded<MultiValue2<TokenIdentifier, BigUint>> {
+        let mut balances = MultiValueEncoded::new();
+
+        for token_id in self.known_tokens().iter() {
+            let balance_for_token = self.balance_for_token(&token_id).get();
+            if balance_for_token > 0 {
+                balances.push((token_id, balance_for_token).into());
+            }
+        }
+
+        balances
+    }
+
+    #[storage_mapper("knownTokens")]
+    fn known_tokens(&self) -> UnorderedSetMapper<TokenIdentifier>;
+
+    #[storage_mapper("balanceForToken")]
+    fn balance_for_token(&self, token_id: &TokenIdentifier) -> SingleValueMapper<BigUint>;
+}

--- a/royalties-handler/wasm/src/lib.rs
+++ b/royalties-handler/wasm/src/lib.rs
@@ -7,6 +7,20 @@
 elrond_wasm_node::wasm_endpoints! {
     royalties_handler
     (
+        addShareholders
+        claimNftMinterPaymentsAndRoyalties
+        claimRewards
+        claimableTokensForRewardEntry
+        createNewRewardEntry
+        getClaimWhitelistForEntry
+        getClaimableEntryIdsForAddress
+        getLastClaimEpoch
+        getLastEntryId
+        getLastRewardEntryEpoch
+        getNftMinterScAddress
+        getShareholders
+        getTokenBalances
+        removeShareholders
     )
 }
 


### PR DESCRIPTION
A SC that splits royalties and mint payments between a list of shareholders. The payments are not sent automatically, each user has to claim on their own. The owner may add/remove shareholders at will.

 The basic flow works as follows:
- at most once per epoch, the owner calls `claimNftMinterPaymentsAndRoyalties`, which will move the funds from the `NftMinter` SC into the Royalties SC
- after the claim (and only if the claim was previously done in the same epoch), the owner calls `createNewRewardEntry`, which splits the accumulated payments and saves an array of payments. This also copies the shareholders list into a temporary mapper. More details and arguments for this below.
- users may claim their payments through `claimRewards`, which sends the rewards for any number of entries the user chooses

Why copy the whole shareholders mapper on each new claim entry?
I found no other way that I liked. The main problem is the shareholder list _can_ change while claiming is in progress, so we can't use references to the initial list. Alternatives I've thought about:
- storing a "claimed" boolean flag per user per entry - very high storage usage, and pretty much impossible to clean without a lot of manual work from the owner
- storing the shareholder list under a single storage entry, as a ManagedVec - claim gas costs would fluctuate too much depending on claim order AND shareholder list order
- keep only an index to the original shareholder list instead of the entire address - the shareholder list uses swap_remove on removal, so the order is not maintained

The current implementation costs a bit more for creating an entry, but the storage will clean itself up automatically as accounts claim their rewards.