### PR TITLE
mint whitelist

### DIFF
--- a/nft-minter/src/common_storage.rs
+++ b/nft-minter/src/common_storage.rs
@@ -17,6 +17,7 @@ pub struct BrandInfo<M: ManagedTypeApi> {
     pub media_type: MediaType<M>,
     pub royalties: BigUint<M>,
     pub mint_period: TimePeriod,
+    pub whitelist_expire_timestamp: u64,
 }
 
 #[derive(TypeAbi, TopEncode, TopDecode, NestedEncode, NestedDecode, PartialEq, Debug)]
@@ -70,4 +71,8 @@ pub trait CommonStorageModule {
         &self,
         brand_id: &BrandId<Self::Api>,
     ) -> SingleValueMapper<ManagedVec<Tag<Self::Api>>>;
+
+    #[view(getMintWhitelist)]
+    #[storage_mapper("mintWhitelist")]
+    fn mint_whitelist(&self, brand_id: &BrandId<Self::Api>) -> UnorderedSetMapper<ManagedAddress>;
 }

--- a/nft-minter/tests/nft_minter_interactor/mod.rs
+++ b/nft-minter/tests/nft_minter_interactor/mod.rs
@@ -94,6 +94,7 @@ where
             FIRST_TAGS,
             FIRST_TIERS,
             FIRST_NFT_AMOUNTS,
+            0,
         )
         .assert_ok();
 
@@ -111,6 +112,7 @@ where
             SECOND_TAGS,
             SECOND_TIERS,
             SECOND_NFT_AMOUNTS,
+            0,
         )
         .assert_ok();
 
@@ -168,6 +170,7 @@ where
         tags: &[&[u8]],
         tiers: &[&[u8]],
         nr_nfts_per_tier: &[usize],
+        whitelist_expire_epoch: u64,
     ) -> TxResult {
         self.b_mock.execute_tx(
             &self.owner_address,
@@ -205,6 +208,7 @@ where
                     managed_token_id!(mint_price_token_id),
                     managed_buffer!(token_display_name),
                     managed_buffer!(token_ticker),
+                    whitelist_expire_epoch,
                     managed_tags,
                     tier_args,
                 );

--- a/nft-minter/wasm/src/lib.rs
+++ b/nft-minter/wasm/src/lib.rs
@@ -8,6 +8,7 @@ elrond_wasm_node::wasm_endpoints! {
     nft_minter
     (
         callBack
+        addToWhitelist
         addUserToAdminList
         buyRandomNft
         claimMintPayments
@@ -20,6 +21,7 @@ elrond_wasm_node::wasm_endpoints! {
         getCollectionsCategory
         getMaxNftsPerTransaction
         getMintPaymentsClaimAddress
+        getMintWhitelist
         getNftTiersForBrand
         getNftTokenIdForBrand
         getPriceForTier
@@ -30,9 +32,11 @@ elrond_wasm_node::wasm_endpoints! {
         giveawayNfts
         issueTokenForBrand
         nftIdOffsetForTier
+        removeFromWhitelist
         removeUserFromAdminList
         setMaxNftsPerTransaction
         setMintPaymentsClaimAddress
+        setMintWhitelistExpireTimestamp
         setRoyaltiesClaimAddress
     )
 }

--- a/royalties-handler/tests/nft_minter_setup/mod.rs
+++ b/royalties-handler/tests/nft_minter_setup/mod.rs
@@ -211,6 +211,7 @@ where
                     managed_token_id!(mint_price_token_id),
                     managed_buffer!(token_display_name),
                     managed_buffer!(token_ticker),
+                    0,
                     managed_tags,
                     tier_args,
                 );


### PR DESCRIPTION
Mint whitelist until a specific timestamp. Originally, the idea was to use epochs, but since mint times are also using block timestamps, this makes it more consistent.